### PR TITLE
Extend "Twig Var Dumper" doc (configure Twig-Debug)

### DIFF
--- a/doc/twig_var_dumper.md
+++ b/doc/twig_var_dumper.md
@@ -53,3 +53,24 @@ class ApplicationDependencyProvider extends SprykerApplicationDependencyProvider
     }
 }
 ```
+
+Configuration
+------------
+
+Make sure that both Yves and Zed have the "debug" option enabled for Twig, otherwise the Twig\Environment will skip the dump-function.
+
+```php
+// config/Shared/config_default-%env%.php
+
+$config[TwigConstants::YVES_TWIG_OPTIONS] = [
+    ...
+    'debug' => true
+];
+
+...
+
+$config[TwigConstants::ZED_TWIG_OPTIONS] = [
+    ...
+    'debug' => true
+];
+```


### PR DESCRIPTION
Twig must be in debug mode for the "dump" to work, therefore I have extended the docs accordingly.