### PR TITLE
fixed missing return-code constant

### DIFF
--- a/src/Zed/SprykerDebug/Communication/Console/DebugConfigConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/DebugConfigConsole.php
@@ -41,7 +41,7 @@ class DebugConfigConsole extends Console
 
         $this->renderTable($output, $config);
 
-        return self::SUCCESS;
+        return self::CODE_SUCCESS;
     }
 
     private function extractConfiguration(): array

--- a/src/Zed/SprykerDebug/Communication/Console/DebugQueuesConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/DebugQueuesConsole.php
@@ -67,6 +67,6 @@ class DebugQueuesConsole extends Console
         }
         $table->render();
 
-        return self::SUCCESS;
+        return self::CODE_SUCCESS;
     }
 }

--- a/src/Zed/SprykerDebug/Communication/Console/DebugQueuesPeekConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/DebugQueuesPeekConsole.php
@@ -44,7 +44,7 @@ class DebugQueuesPeekConsole extends Console
             $output->writeln($this->formatPayload($input, $message->payload()), OutputInterface::OUTPUT_RAW);
         }
 
-        return self::SUCCESS;
+        return self::CODE_SUCCESS;
     }
 
     private function formatPayload(InputInterface $input, string $message): string

--- a/src/Zed/SprykerDebug/Communication/Console/PropelDumpEntityConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/PropelDumpEntityConsole.php
@@ -69,7 +69,7 @@ class PropelDumpEntityConsole extends Console
         } catch (PropelException $exception) {
             $output->writeln('<error>' . $exception->getMessage() . '</>');
 
-            return self::SUCCESS;
+            return self::CODE_SUCCESS;
         }
 
         if ($input->getOption(self::OPT_RECORDS)) {
@@ -80,7 +80,7 @@ class PropelDumpEntityConsole extends Console
 
         $output->writeln(sprintf('%s entities', count($entities)));
 
-        return self::SUCCESS;
+        return self::CODE_SUCCESS;
     }
 
     private function buildQuery(TableMap $table, InputInterface $input): ModelCriteria


### PR DESCRIPTION
After a fresh install without problems concerning composer-requirements and so on I was able to run e.g. the `debug:config` command, and it outputs what I expect, but it fails to return it's success-statuscode in the end.

```
Error - Exception: Undefined class constant 'SUCCESS'
in /data/vendor/inviqa/spryker-debug/src/Zed/SprykerDebug/Communication/Console/DebugConfigConsole.php (44)
```

The console command extends `Spryker\Zed\Kernel\Communication\Console\Console` which has a success-constant named _CODE_SUCCESS_
See: https://github.com/spryker/kernel/blob/c2dfcdefcf8e17f224b4283abdcf5d9c0eb7c843/src/Spryker/Zed/Kernel/Communication/Console/Console.php#L39 
