### PR TITLE
Add PHP8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - '7.3'
           - '7.4'
           - '8.0'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         php-version:
           - '7.3'
           - '7.4'
+          - '8.0'
 
     steps:
       -

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
       }
     },
     "require": {
-        "php": "^7.2 | ^8.0",
+        "php": "^7.4 | ^8.0",
         "spryker-shop/shop-application": "^1.0",
         "spryker/propel": "^3.0",
         "spryker/console": "^4.0",
@@ -36,7 +36,7 @@
         "propel/propel": "2.0.0-alpha12",
         "behat/behat": "^3.5",
         "spryker-sdk/phpstan-spryker": "^0.4",
-        "roave/behat-psr11extension": "^1.0",
+        "roave/behat-psr11extension": "^2.1",
         "webmozart/path-util": "^2.0",
         "spryker/code-sniffer": "^0.17.7",
         "spryker-shop/web-profiler-widget": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
       }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 | ^8.0",
         "spryker-shop/shop-application": "^1.0",
         "spryker/propel": "^3.0",
         "spryker/console": "^4.0",
@@ -38,12 +38,14 @@
         "spryker-sdk/phpstan-spryker": "^0.4",
         "roave/behat-psr11extension": "^1.0",
         "webmozart/path-util": "^2.0",
-        "spryker/code-sniffer": "^0.14",
+        "spryker/code-sniffer": "^0.17.7",
         "spryker-shop/web-profiler-widget": "^1.4",
         "spryker/web-profiler": "^1.6",
         "spryker/router": "^1.3",
         "spryker/http": "^1.0",
-        "spryker/event-dispatcher": "^1.0"
+        "spryker/event-dispatcher": "^1.0",
+        "phpstan/phpdoc-parser": "^1.6",
+        "slevomat/coding-standard": "^7.2"
     },
     "extra": {
         "branch-alias": {

--- a/src/Shared/SprykerDebug/Plugin/Guzzle/GuzzleStopwatchProfilerMiddleware.php
+++ b/src/Shared/SprykerDebug/Plugin/Guzzle/GuzzleStopwatchProfilerMiddleware.php
@@ -10,7 +10,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
 class GuzzleStopwatchProfilerMiddleware implements MiddlewareInterface
 {
     /**
-     * @var Stopwatch
+     * @var \Symfony\Component\Stopwatch\Stopwatch
      */
     private $stopwatch;
 

--- a/src/Zed/SprykerDebug/Communication/Console/AbstractShellConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/AbstractShellConsole.php
@@ -19,7 +19,7 @@ class AbstractShellConsole extends Console
         if ($path === null) {
             throw new RuntimeException(sprintf(
                 'Shell "%s" not found, maybe you need to install it?',
-                $shellName
+                $shellName,
             ));
         }
 

--- a/src/Zed/SprykerDebug/Communication/Console/DatabaseShellConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/DatabaseShellConsole.php
@@ -37,7 +37,7 @@ class DatabaseShellConsole extends AbstractShellConsole
                 'PGHOST' => Config::get(PropelConstants::ZED_DB_HOST),
                 'PGDATABASE' => Config::get(PropelConstants::ZED_DB_DATABASE),
                 'PGPORT' => Config::get(PropelConstants::ZED_DB_PORT),
-            ]
+            ],
         );
         $output->getErrorOutput()->writeln(sprintf('<comment>Executing "%s" (connection params passed via env vars)</comment>', $process->getCommandLine()));
         $output->getErrorOutput()->writeln('<info>Type "\\q" to quit</info>');

--- a/src/Zed/SprykerDebug/Communication/Console/DebugConfigConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/DebugConfigConsole.php
@@ -16,8 +16,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 class DebugConfigConsole extends Console
 {
     private const NAME = 'debug:config';
+
     private const DESCRIPTION = 'Inspect the current Spryker configuration';
+
     private const ARG_FILTER = 'filter';
+
     private const OPT_ORIGIN = 'origin';
 
     public function configure(): void
@@ -33,7 +36,7 @@ class DebugConfigConsole extends Console
         $config = $this->extractConfiguration();
         $config = $this->filterConfig(
             $config,
-            Cast::toStringOrNull($input->getArgument(self::ARG_FILTER))
+            Cast::toStringOrNull($input->getArgument(self::ARG_FILTER)),
         );
         $config = $this->sortConfiguration($config);
         $config = $this->addOrigin($config);

--- a/src/Zed/SprykerDebug/Communication/Console/DebugQueuesConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/DebugQueuesConsole.php
@@ -16,7 +16,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 class DebugQueuesConsole extends Console
 {
     public const OPT_VHOST = 'vhost';
+
     public const ARG_PATTERN = 'pattern';
+
     public const OPT_NON_EMPTY = 'non-empty';
 
     public function configure(): void

--- a/src/Zed/SprykerDebug/Communication/Console/DebugQueuesPeekConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/DebugQueuesPeekConsole.php
@@ -16,8 +16,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 class DebugQueuesPeekConsole extends Console
 {
     private const ARG_NAME = 'peek';
+
     private const OPT_VHOST = 'vhost';
+
     private const OPT_JSON = 'json';
+
     private const OPT_COUNT = 'count';
 
     public function configure(): void
@@ -37,7 +40,7 @@ class DebugQueuesPeekConsole extends Console
         $messages = $client->peek(
             Cast::toString($input->getOption(self::OPT_VHOST)),
             Cast::toString($input->getArgument(self::ARG_NAME)),
-            Cast::toInt($input->getOption(self::OPT_COUNT))
+            Cast::toInt($input->getOption(self::OPT_COUNT)),
         );
 
         foreach ($messages as $message) {
@@ -54,14 +57,14 @@ class DebugQueuesPeekConsole extends Console
             if ($decoded === false) {
                 throw new RuntimeException(sprintf(
                     'Could not decode JSON: "%s"',
-                    json_last_error_msg()
+                    json_last_error_msg(),
                 ));
             }
 
             $encoded = json_encode($decoded, JSON_PRETTY_PRINT);
             if ($encoded === false) {
                 throw new RuntimeException(
-                    'Could not encode JSON'
+                    'Could not encode JSON',
                 );
             }
 

--- a/src/Zed/SprykerDebug/Communication/Console/PropelDumpEntityConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/PropelDumpEntityConsole.php
@@ -24,18 +24,22 @@ use Symfony\Component\Console\Output\OutputInterface;
 class PropelDumpEntityConsole extends Console
 {
     private const ARG_NAME = 'name';
+
     private const OPT_BY = 'by';
+
     private const OPT_LIMIT = 'limit';
+
     private const OPT_RECORDS = 'records';
+
     private const OPT_FIELDS = 'fields';
 
     /**
-     * @var CriteriaParser
+     * @var \Inviqa\Zed\SprykerDebug\Communication\Model\Propel\CriteriaParser
      */
     private $criteriaParser;
 
     /**
-     * @var FieldParser
+     * @var \Inviqa\Zed\SprykerDebug\Communication\Model\Propel\FieldParser
      */
     private $fieldParser;
 
@@ -64,7 +68,7 @@ class PropelDumpEntityConsole extends Console
 
         try {
             $entities = $query->findByArray($this->criteriaParser->parseMany(
-                Cast::toArray($input->getOption(self::OPT_BY))
+                Cast::toArray($input->getOption(self::OPT_BY)),
             ));
         } catch (PropelException $exception) {
             $output->writeln('<error>' . $exception->getMessage() . '</>');
@@ -93,7 +97,7 @@ class PropelDumpEntityConsole extends Console
             throw new RuntimeException(sprintf(
                 'Could not find query class "%s" for "%s"',
                 $queryClass,
-                $table->getClassName()
+                $table->getClassName(),
             ));
         }
         $query = new $queryClass();
@@ -149,13 +153,13 @@ class PropelDumpEntityConsole extends Console
     private function entityToCells($entity): array
     {
         if (is_scalar($entity)) {
-            return [ $entity ];
+            return [$entity];
         }
 
         if ($entity instanceof ActiveRecordInterface) {
             if (!method_exists($entity, 'toArray')) {
                 throw new RuntimeException(
-                    'Active record has no ->toArray method'
+                    'Active record has no ->toArray method',
                 );
             }
             $entity = $entity->toArray();
@@ -164,7 +168,7 @@ class PropelDumpEntityConsole extends Console
         if (!is_array($entity)) {
             throw new RuntimeException(sprintf(
                 'Entity/row data is not an array, is "%s"',
-                gettype($entity)
+                gettype($entity),
             ));
         }
 

--- a/src/Zed/SprykerDebug/Communication/Console/PropelDumpMetadataConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/PropelDumpMetadataConsole.php
@@ -31,7 +31,7 @@ class PropelDumpMetadataConsole extends Console
         $selected = $input->getArgument(self::ARG_PATTERN);
         $tables = $this->getFactory()->createPropelTablesFactory()->createTables();
 
-        if (empty($selected)) {
+        if (!$selected) {
             $selected = $style->choice('Select entity:', array_map(function (TableMap $tableMap) {
                 return sprintf('%s', $tableMap->getName());
             }, $tables->toArray()));
@@ -80,7 +80,7 @@ class PropelDumpMetadataConsole extends Console
             ['class' => $table->getClassName()],
             ['collection' => $table->getCollectionClassName()],
             ['table' => $table->getName()],
-            ['primaryKeys' => json_encode($table->getPrimaryKeys())]
+            ['primaryKeys' => json_encode($table->getPrimaryKeys())],
         );
     }
 
@@ -117,7 +117,7 @@ class PropelDumpMetadataConsole extends Console
                     return $column->getName();
                 }, $relation->getLocalColumns())),
                 $this->relationType($relation->getType()),
-                $relation->getForeignTable()->getName()
+                $relation->getForeignTable()->getName(),
             ));
         }
     }

--- a/src/Zed/SprykerDebug/Communication/Console/RedisShellConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/RedisShellConsole.php
@@ -32,7 +32,7 @@ class RedisShellConsole extends AbstractShellConsole
             null,
             [
                 'REDISCLI_AUTH' => Config::get('STORAGE_REDIS:STORAGE_REDIS_PASSWORD', Config::get(StorageConstants::STORAGE_REDIS_PASSWORD, '')),
-            ]
+            ],
         );
         $output->getErrorOutput()->writeln(sprintf('<comment>Executing "%s" (password passed via env REDISCLI_AUTH)</comment>', $process->getCommandLine()));
         $output->getErrorOutput()->writeln('<info>Type "exit" to quit</info>');

--- a/src/Zed/SprykerDebug/Communication/Model/Propel/FieldParser.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Propel/FieldParser.php
@@ -8,7 +8,7 @@ final class FieldParser
     {
         $fields = trim($fields);
 
-        if (empty($fields)) {
+        if (!$fields) {
             return [];
         }
 

--- a/src/Zed/SprykerDebug/Communication/Model/Propel/TableNameFinder.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Propel/TableNameFinder.php
@@ -12,12 +12,12 @@ use Symfony\Component\Finder\Finder;
 class TableNameFinder
 {
     /**
-     * @var PropelConfig
+     * @var \Inviqa\Zed\SprykerDebug\Model\Propel\PropelConfig
      */
     private $config;
 
     /**
-     * @var PhpNameGenerator
+     * @var \Propel\Generator\Model\PhpNameGenerator
      */
     private $nameGenerator;
 
@@ -51,7 +51,8 @@ class TableNameFinder
         }
 
         // spryker does not seem to have consistent XML namespace
-        foreach ([
+        foreach (
+            [
             'sprk' => 'spryker:schema-01',
             '' => '',
             ] as $alias => $namespace

--- a/src/Zed/SprykerDebug/Communication/Model/Propel/Tables.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Propel/Tables.php
@@ -47,7 +47,7 @@ class Tables implements IteratorAggregate
 
         throw new TableNotFoundException(sprintf(
             'Could not find table map "%s" (using either PHP or table name)',
-            $phpOrTableName
+            $phpOrTableName,
         ));
     }
 }

--- a/src/Zed/SprykerDebug/Communication/Model/Propel/TablesFactory.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Propel/TablesFactory.php
@@ -8,12 +8,12 @@ use Propel\Runtime\Map\Exception\TableNotFoundException;
 class TablesFactory
 {
     /**
-     * @var DatabaseMap
+     * @var \Propel\Runtime\Map\DatabaseMap
      */
     private $map;
 
     /**
-     * @var TableNameFinder
+     * @var \Inviqa\Zed\SprykerDebug\Communication\Model\Propel\TableNameFinder
      */
     private $finder;
 

--- a/src/Zed/SprykerDebug/Communication/Model/Rabbit/Queue.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Rabbit/Queue.php
@@ -60,7 +60,7 @@ class Queue
             $data['messages_ready'] ?? -1,
             $data['messages_unacknowledged'] ?? -1,
             $data['messages'] ?? -1,
-            $data['vhost'] ?? ''
+            $data['vhost'] ?? '',
         );
     }
 

--- a/src/Zed/SprykerDebug/Communication/Model/Rabbit/RabbitClient.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Rabbit/RabbitClient.php
@@ -8,7 +8,7 @@ use RuntimeException;
 final class RabbitClient
 {
     /**
-     * @var Client
+     * @var \GuzzleHttp\Client
      */
     private $client;
 
@@ -18,7 +18,7 @@ final class RabbitClient
     }
 
     /**
-     * @return Queues<Queue>
+     * @return \Inviqa\Zed\SprykerDebug\Communication\Model\Rabbit\Queues<\Inviqa\Zed\SprykerDebug\Communication\Model\Rabbit\Queue>
      */
     public function queues(): Queues
     {
@@ -32,9 +32,9 @@ final class RabbitClient
         $decoded = json_decode(
             $this->client->request(
                 'GET',
-                sprintf('/api/%s', $url)
+                sprintf('/api/%s', $url),
             )->getBody()->__toString(),
-            true
+            true,
         );
 
         if ($decoded === false) {
@@ -52,9 +52,9 @@ final class RabbitClient
                 sprintf('/api/%s', $url),
                 [
                     'json' => $options,
-                ]
+                ],
             )->getBody()->__toString(),
-            true
+            true,
         );
 
         if ($decoded === false) {

--- a/src/Zed/SprykerDebug/Communication/SprykerDebugCommunicationFactory.php
+++ b/src/Zed/SprykerDebug/Communication/SprykerDebugCommunicationFactory.php
@@ -24,7 +24,7 @@ class SprykerDebugCommunicationFactory extends AbstractCommunicationFactory
                 'base_uri' => sprintf(
                     'http://%s:%s/api',
                     Config::get(RabbitMqEnv::RABBITMQ_API_HOST),
-                    Config::get(RabbitMqEnv::RABBITMQ_API_PORT)
+                    Config::get(RabbitMqEnv::RABBITMQ_API_PORT),
                 ),
                 'auth' => [
                     Config::get(RabbitMqEnv::RABBITMQ_API_USERNAME),
@@ -33,7 +33,7 @@ class SprykerDebugCommunicationFactory extends AbstractCommunicationFactory
                 'headers' => [
                     'Content-Type' => 'application/json',
                 ],
-            ])
+            ]),
         );
     }
 


### PR DESCRIPTION
Added support for PHP8.x:

- Updated composer minimum PHP version
- Updated packages pinned to PHP7.x
- Extended tests to run a PHP8.0 environment
- Misc changes from `phpcbf`

```
+------------------------------------------------+---------+--------+-------------------------------------------------------------------+
| Dev Changes                                    | From    | To     | Compare                                                           |
+------------------------------------------------+---------+--------+-------------------------------------------------------------------+
| phpstan/phpdoc-parser                          | 0.3.5   | 1.6.2  | https://github.com/phpstan/phpdoc-parser/compare/0.3.5...1.6.2    |
| slevomat/coding-standard                       | 5.0.4   | 7.2.1  | https://github.com/slevomat/coding-standard/compare/5.0.4...7.2.1 |
| spryker/code-sniffer                           | 0.14.12 | 0.17.7 | https://github.com/spryker/code-sniffer/compare/0.14.12...0.17.7  |
| dealerdirect/phpcodesniffer-composer-installer | NEW     | v0.7.2 |                                                                   |
+------------------------------------------------+---------+--------+-------------------------------------------------------------------+
```