### PR TITLE
Allow projects to upgrade to symfony/var-dumper version v6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "spryker/console": "^4.0",
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "spryker/rabbit-mq": "^2.0",
-        "symfony/var-dumper": "^4.0|^5.0",
+        "symfony/var-dumper": "^4.0|^5.0|^6.0",
         "spryker/zed-request": "^3.8"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,7 @@
         "spryker/router": "^1.3",
         "spryker/http": "^1.0",
         "spryker/event-dispatcher": "^1.0",
-        "phpstan/phpdoc-parser": "^1.6",
-        "slevomat/coding-standard": "^7.2"
+        "phpstan/phpdoc-parser": "^1.6"
     },
     "extra": {
         "branch-alias": {

--- a/src/Zed/SprykerDebug/Communication/Model/Propel/TableNameFinder.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Propel/TableNameFinder.php
@@ -68,7 +68,7 @@ class TableNameFinder
                     $entityNamespace,
                     '\\',
                     $this->nameGenerator->generateName([
-                        $tableEl->attributes->getNamedItem('name')->value,
+                        $tableEl->attributes->getNamedItem('name')->nodeValue,
                         PhpNameGenerator::CONV_METHOD_PHPNAME,
                     ]),
                 ]);


### PR DESCRIPTION
As time marches on Symfony brings out new major versions of things. Spryker is now supporting v6.x modules, but the debug module is keeping var-dumper at version 5.x, which then has a knock on effect preventing a clean upgrade.

In our case some modules were downgraded to beta versions.

I've locally tested the debug module with var-dumper v6.4.2 and all is well, so I've created this PR for this change:

- Allow `symfony/var-dumper` v6.x
- Change `TableNameFinder`, because PHPStan was complaining so this has been updated to the correct variable for `DOMNode`
- Allow v8.x version of `slevomat/coding-standard`, because the latest version of `spryker/code-sniffer` requires it